### PR TITLE
Update (and reduce) dependencies

### DIFF
--- a/notifications/pnp4n_send_host_mail.pl
+++ b/notifications/pnp4n_send_host_mail.pl
@@ -653,7 +653,7 @@ sub import_pnp_graph {
 
   # Download the image
   my $ua = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0,
-                                             SSL_verify_mode => SSL_VERIFY_NONE,}, );
+                                             SSL_verify_mode => SSL_VERIFY_NONE } );
 
   # Check if web authentication is required
   if (defined($pnp4nagios_auth)) {

--- a/notifications/pnp4n_send_host_mail.pl
+++ b/notifications/pnp4n_send_host_mail.pl
@@ -30,6 +30,7 @@
 # Depends : perl-Mail-Sendmail (Mail::Sendmail)                         #
 #           perl-MIME-tools (MIME::Base64)                              #
 #           perl-libwww-perl-6.03-2.1.2.noarch (LWP)                    #
+#           perl-LWP-Protocol-https (https support for LWP)             #
 #           libnetpbm (conversion png-to-jpg)                           #
 #           netpbm (see above)                                          #
 # ##################################################################### #

--- a/notifications/pnp4n_send_host_mail.pl
+++ b/notifications/pnp4n_send_host_mail.pl
@@ -639,7 +639,7 @@ sub b64encode_img {
 sub import_pnp_graph {
   use LWP;
   use FileHandle;
-  use Net::SSL;
+  use IO::Socket::SSL;
   $tstamp = time();
 
   # This sets the graph history
@@ -652,7 +652,8 @@ sub import_pnp_graph {
   $tmpfile = $fhandle->filename;
 
   # Download the image
-  my $ua = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0}, );
+  my $ua = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0,
+                                             SSL_verify_mode => SSL_VERIFY_NONE,}, );
 
   # Check if web authentication is required
   if (defined($pnp4nagios_auth)) {

--- a/notifications/pnp4n_send_service_mail.pl
+++ b/notifications/pnp4n_send_service_mail.pl
@@ -698,7 +698,7 @@ sub import_pnp_graph {
 
   # Download the image
   my $ua = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0,
-                                             SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE,}, );
+                                             SSL_verify_mode => SSL_VERIFY_NONE } );
 
   # Check if web authentication is required
   if (defined($pnp4nagios_auth)) {

--- a/notifications/pnp4n_send_service_mail.pl
+++ b/notifications/pnp4n_send_service_mail.pl
@@ -30,6 +30,7 @@
 # Depends : perl-Mail-Sendmail (Mail::Sendmail)                         #
 #           perl-MIME-tools (MIME::Base64)                              #
 #           perl-libwww-perl-6.03-2.1.2.noarch (LWP)                    #
+#           perl-LWP-Protocol-https (https support for LWP)             #
 #           libnetpbm (conversion png-to-jpg)                           #
 #           netpbm (see above)                                          #
 # ##################################################################### #

--- a/notifications/pnp4n_send_service_mail.pl
+++ b/notifications/pnp4n_send_service_mail.pl
@@ -683,7 +683,7 @@ sub b64encode_img {
 sub import_pnp_graph { 
   use LWP;
   use FileHandle;
-  use Net::SSL;
+  use IO::Socket::SSL;
   $tstamp = time();
 
   # This sets the graph history
@@ -696,7 +696,8 @@ sub import_pnp_graph {
   $tmpfile = $fhandle->filename;
 
   # Download the image
-  my $ua = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0}, );
+  my $ua = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0,
+                                             SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE,}, );
 
   # Check if web authentication is required
   if (defined($pnp4nagios_auth)) {


### PR DESCRIPTION
Tontonitch added option to ignore host check by adding Net::SSL module configurations, however this module adds a dependency on another external library.

The same feature can be added without adding another module requirement (using the newer perl module:  IO::Socket::SSL)  Also included is the (probable intent?) feature to ignore invalid SSL Certificates.

Documenting an additional dependency is also required now that perl-libwww-perl does not include https support:  perl-LWP-Protocol-https-6.0Xxx.noarch